### PR TITLE
Remove eval-when-compile

### DIFF
--- a/ac-mozc.el
+++ b/ac-mozc.el
@@ -1,7 +1,7 @@
 ;; -*- coding: utf-8 -*-
 ;;; ac-mozc.el --- An auto-complete source for Mozc
 
-(eval-when-compile (require 'cl))
+(require 'cl)
 (require 'mozc)
 (require 'auto-complete)
 


### PR DESCRIPTION
Because `mapcan` is a function. We should use `eval-when-compile`
if package uses only cl macros.
