### PR TITLE
Add mozc dependency

### DIFF
--- a/ac-mozc.el
+++ b/ac-mozc.el
@@ -5,7 +5,7 @@
 ;; Author: igjit <igjit1@gmail.com>
 ;; URL: https://github.com/igjit/ac-mozc
 ;; Version: 0.0.3
-;; Package-Requires: ((cl-lib "0.5") (auto-complete "1.4"))
+;; Package-Requires: ((cl-lib "0.5") (auto-complete "1.4") (mozc "0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
`mozc`が [MELPAに登録された](https://github.com/milkypostman/melpa/pull/2530)ので, `mozc`を依存関係に追加しました. これで `ac-mozc`が MELPAに登録できるようになります.
